### PR TITLE
Basic support for ETD

### DIFF
--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -53,7 +53,7 @@ module Fedex
       def initialize(credentials, options={})
         requires!(options, :shipper, :recipient, :packages)
         @credentials = credentials
-        @shipper, @recipient, @packages, @service_type, @customs_clearance_detail, @debug = options[:shipper], options[:recipient], options[:packages], options[:service_type], options[:customs_clearance_detail], options[:debug]
+        @shipper, @recipient, @packages, @service_type, @customs_clearance_detail, @debug, @document_specification = options[:shipper], options[:recipient], options[:packages], options[:service_type], options[:customs_clearance_detail], options[:debug], options[:document_specification]
         @origin = options[:origin]
         @debug ||= ENV['DEBUG'] == 'true'
         @shipping_options =  options[:shipping_options] ||={}

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -100,6 +100,7 @@ module Fedex
       end
 
       def add_shipping_document_specification(xml)
+        # ToDo: Save and return this file with the label
         xml.ShippingDocumentSpecification {
           xml.ShippingDocumentTypes @document_specification[:shipping_document_types]
           if @document_specification[:commercial_invoice_detail]


### PR DESCRIPTION
The gem already has basic support for documents, but from what I can tell it only supports it as a completely separate call. This allows it to be called/generated while generating the label which is required for ETD if you want FEdEx to generate the CI. 
It may be better practice to use the already-used document class, I'm really not sure so I'm open to rewrites here. FWIW, this as-is works for our specific scenario. 
However, this does NOT return the invoice back to the client (Added a todo for that)